### PR TITLE
fix register function and add accounts bin to user profiles

### DIFF
--- a/frontend/src/components/RegisterButton.js
+++ b/frontend/src/components/RegisterButton.js
@@ -7,7 +7,7 @@ import { getAuth, createUserWithEmailAndPassword, updateProfile, updateEmail } f
 import { useSignInWithGoogle } from '../lib/hooks';
 import { useNavigate } from 'react-router';
 import { FormControl, InputLabel, InputAdornment, FilledInput } from '@mui/material';
-
+import { firestore } from '../utils/firebase';
 import IconButton from '@mui/material/IconButton';
 import GoogleIcon from '@mui/icons-material/Google';
 import Visibility from '@mui/icons-material/Visibility';
@@ -87,9 +87,17 @@ const RegisterButton = () => {
             });
 
           updateEmail(userCredential.user, values.email)
-            .then(() => {
+          
+          firestore.doc(`users/${userCredential.user.uid}`).get().then((docSnapshot) => {
+              //add user data
+              firestore.doc(`users/${userCredential.user.uid}`).set({
+                accounts: [],
+                email: values.email,
+                displayName: values.username
+              });
               // then navigates to the dashboard after registering
-              navigate('/dashboard');
+            
+              navigate('/');
             })
             .catch((error) => {
               console.log(error);

--- a/frontend/src/lib/firestore.js
+++ b/frontend/src/lib/firestore.js
@@ -16,6 +16,7 @@ export const createUserInFirebase = async (user) => {
       userDocument.set({
         email,
         displayName,
+        accounts: []
       }); // If the user doesn't exist, add them to the db.
     }
   });

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -10,4 +10,5 @@
 # add below the next line your own json file name
 # Silas's json admin credential file, don't delete please.
 northark-4aee9-firebase-adminsdk-kznpr-02d7b35570.json
+woahjson.json
 


### PR DESCRIPTION
Fixed the register function to allow setting of displayNames and emails

Added an "accounts" array to the user creation/registration function to allow for Plaid account keys to be stored in one unified location in firebase.